### PR TITLE
bug : DateSelectorCalendar 컴포넌트 FestivalCard에 가리는 문제

### DIFF
--- a/app/(home)/components/DateSelector/DateSelectorCalendar.tsx
+++ b/app/(home)/components/DateSelector/DateSelectorCalendar.tsx
@@ -23,7 +23,7 @@ export default function DateSelectorCalendar({
     const { eventDate, setEventDate } = useEventDateStore();
 
     return (
-        <div className="relative md:max-w-[335px] w-full">
+        <div className="relative md:max-w-[335px] w-full md:z-10">
             <div className="min-w-[335px] md:max-w-[335px] py-[16px] px-[14px] border border-border-base bg-background-base flex flex-col rounded-[8px] gap-[20px] md:shadow-window drag-prevent animation-color md:absolute">
                 {/* icon | MM.DD (e) ~ MM.DD (e) */}
                 <div className="row-center gap-[10px]">


### PR DESCRIPTION
## DateSelectorCalendar 컴포넌트 FestivalCard에 가리는 문제

|![2025-06-09 02 30 14](https://github.com/user-attachments/assets/1a024f77-25a3-425b-a78f-acf221c0aebf)|![2025-06-09 10 08 09](https://github.com/user-attachments/assets/9c47d6b7-12cd-49d1-b540-436c308f7b8e)|
|--|--|
|수정 전|z-index값 추가|

### ✅ 작업 내용
- [x] DateSelectorCalender에 z-index 값 추가

### 기타
없음

close #33 
