### PR TITLE
feature : detail page 메타데이터 타이틀과 설명 추가

### DIFF
--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { describe } from "node:test";
 import {
     getFestivalCommon,
     getFestivalContents,

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -30,7 +30,9 @@ export default function Button({
                 isBorder ? borderStyle : ""
             }`}
         >
-            {icon ? <img src={icon} className=" w-[15px] h-[15px]" /> : null}
+            {icon ? (
+                <img src={icon} alt={icon} className=" w-[15px] h-[15px]" />
+            ) : null}
             {title}
         </button>
     );


### PR DESCRIPTION
## detail page 메타데이터 타이틀과 설명 추가

|![2025-06-22 11 54 53](https://github.com/user-attachments/assets/2e14af7f-430c-4f51-8e7c-14751065eb0f)|![2025-06-22 11 55 07](https://github.com/user-attachments/assets/889c5185-f5f0-4e94-b90c-ba76a6890d4b)|
|--|--|

### ✅ 작업 내용
- [x] 메타데이터 타이틀 축제 이름으로 변경 : 축제이름 - 축제가자 같은 형태로 수정
- [x] 메타데이터 설명 축제 `overview` 설명으로 추가
- [x] `Button` 컴포넌트 아이콘 이미지 alt속성 추가 : 아이콘 이름으로 넣었는데 버튼마다 설명이 다를 수 있기에 수정이 필요해 보입니다.

### 기타
없음

close #57
