### PR TITLE
bug : FestivalCardList 더보기 버튼 오류 수정

### DIFF
--- a/components/FestivalCardList/FestivalCardList.tsx
+++ b/components/FestivalCardList/FestivalCardList.tsx
@@ -156,14 +156,18 @@ export default function FestivalCardList({ listType }: { listType: ListType }) {
             )}
 
             <div className="w-full row-center justify-center mt-[20px] mb-[100px]">
-                {page / 12 !== Math.floor(totalCount / 12 + 1) ? (
-                    <Button
-                        onClick={() => setPage(page + 12)}
-                        title={`더 보기 ${page / 12} / ${Math.floor(
-                            totalCount / 12 + 1
-                        )}`}
-                        isBorder
-                    />
+                {page !== totalCount ? (
+                    page / 12 !== Math.floor(totalCount / 12 + 1) ? (
+                        <Button
+                            onClick={() => setPage(page + 12)}
+                            title={`더 보기 ${page / 12} / ${Math.floor(
+                                totalCount % 12 === 0
+                                    ? totalCount / 12
+                                    : totalCount / 12 + 1
+                            )}`}
+                            isBorder
+                        />
+                    ) : null
                 ) : null}
             </div>
         </div>


### PR DESCRIPTION
## FestivalCardList 더보기 버튼 오류 수정

축제의 개수가 12의 배수(12, 24...)인 경우, 표시되면 안되는 더보기 버튼이 생기는 문제 해결

|![2025-06-27 20 01 31](https://github.com/user-attachments/assets/650a5c3f-a23e-4a93-af96-c04f265040cd)|![2025-06-27 20 02 41](https://github.com/user-attachments/assets/ae743d14-4437-4a2a-9083-126e14245152)|
|--|--|

### ✅ 작업 내용
- [x] 오류 수정

### 기타
없음

close #65
