### PR TITLE
feature : 외부 영역 클릭 시 DateSelectorCalendar 닫힘 및 리팩토링

### DIFF
--- a/app/(home)/components/DateSelector/DateSelectorCalendar.tsx
+++ b/app/(home)/components/DateSelector/DateSelectorCalendar.tsx
@@ -11,6 +11,18 @@ interface DateSelectorCalendarProps {
     close: () => void;
 }
 
+const thisYear = new Date().getFullYear(); // 올해 년도
+
+const PERIODS = {
+    full: ["20100101", "20501231"], // 전체기간
+    lastYear: [`${thisYear - 1}0101`, `${thisYear - 1}1231`], // 작년
+    thisYear: [`${thisYear}0101`, `${thisYear}1231`], // 올해
+    nextYear: [`${thisYear + 1}0101`, `${thisYear + 1}1231`], // 내년
+    today: [getToday(), getToday()], // 오늘
+};
+
+const getConvertedPeriod = (key) => PERIODS[key].map(convertYYYYMMDDToDate);
+
 /**
  * @param 클릭 이벤트 : 닫힘 상태로 변경
  * @returns DateSelectorCalendar 컴포넌트
@@ -19,7 +31,6 @@ export default function DateSelectorCalendar({
     close,
 }: DateSelectorCalendarProps) {
     const { eventDate, setEventDate } = useEventDateStore();
-
     const ref = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -33,34 +44,14 @@ export default function DateSelectorCalendar({
         document.addEventListener("touchstart", handleClickOutside);
 
         return () => {
-            document.addEventListener("mousedown", handleClickOutside);
-            document.addEventListener("touchstart", handleClickOutside);
+            document.removeEventListener("mousedown", handleClickOutside);
+            document.removeEventListener("touchstart", handleClickOutside);
         };
     }, [close]);
 
-    const thisYear = new Date().getFullYear();
-
-    const setPeriod = {
-        lastYear: {
-            start: convertYYYYMMDDToDate(`${thisYear - 1}0101`),
-            end: convertYYYYMMDDToDate(`${thisYear - 1}1231`),
-        },
-        thisYear: {
-            start: convertYYYYMMDDToDate(`${thisYear}0101`),
-            end: convertYYYYMMDDToDate(`${thisYear}1231`),
-        },
-        nextYear: {
-            start: convertYYYYMMDDToDate(`${thisYear + 1}0101`),
-            end: convertYYYYMMDDToDate(`${thisYear + 1}1231`),
-        },
-        today: {
-            start: convertYYYYMMDDToDate(getToday()),
-            end: convertYYYYMMDDToDate(getToday()),
-        },
-        full: {
-            start: convertYYYYMMDDToDate("20100101"),
-            end: convertYYYYMMDDToDate("20501231"),
-        },
+    // 기간 간편 선택 클릭 이벤트
+    const handleSetPeriod = (key) => {
+        setEventDate(getConvertedPeriod(key));
     };
 
     return (
@@ -122,55 +113,30 @@ export default function DateSelectorCalendar({
                     value={eventDate}
                 />
 
-                {/* 2024년 2025년 2026년 전체 */}
+                {/* 빠른 기간 선택 버튼 */}
                 <div className="flex flex-wrap gap-[5px]">
                     <Button
                         title="전체"
-                        onClick={() => {
-                            setEventDate([
-                                setPeriod.full.start,
-                                setPeriod.full.end,
-                            ]);
-                        }}
+                        onClick={() => handleSetPeriod("full")}
                     />
                     <Button
                         title={`작년 (${thisYear - 1}년)`}
-                        onClick={() => {
-                            setEventDate([
-                                setPeriod.lastYear.start,
-                                setPeriod.lastYear.end,
-                            ]);
-                        }}
+                        onClick={() => handleSetPeriod("lastYear")}
                     />
                     <Button
                         title={`올해 (${thisYear}년)`}
-                        onClick={() => {
-                            setEventDate([
-                                setPeriod.thisYear.start,
-                                setPeriod.thisYear.end,
-                            ]);
-                        }}
+                        onClick={() => handleSetPeriod("thisYear")}
                     />
                     <Button
                         title={`내년 (${thisYear + 1}년)`}
-                        onClick={() => {
-                            setEventDate([
-                                setPeriod.nextYear.start,
-                                setPeriod.nextYear.end,
-                            ]);
-                        }}
+                        onClick={() => handleSetPeriod("nextYear")}
                     />
                 </div>
 
                 {/* icon 초기화 | 닫기 */}
                 <div className="row-center justify-between">
                     <button
-                        onClick={() =>
-                            setEventDate([
-                                setPeriod.today.start,
-                                setPeriod.today.end,
-                            ])
-                        }
+                        onClick={() => handleSetPeriod("today")}
                         className="flex flex-row gap-[5px]"
                     >
                         <img
@@ -178,9 +144,7 @@ export default function DateSelectorCalendar({
                             alt="calendar"
                             className="w-[14px]"
                         />
-                        <span className="font-semibold text-[14px]">
-                            오늘로 초기화
-                        </span>
+                        <span className="font-semibold text-[14px]">오늘</span>
                     </button>
 
                     <button


### PR DESCRIPTION
## 외부 영역 클릭 시 DateSelectorCalendar 닫힘 및 리팩토링

![2025-06-29-16-36-33](https://github.com/user-attachments/assets/1d419ed4-ec27-48bb-9dbc-af261f4a3d02)

`DateSelectorCalendar` 컴포넌트 외부 영역 클릭 시 닫힘을 구현하였습니다.

코드를 리팩토링 하였습니다.

### ✅ 작업 내용
- [x] 외부 영역 클릭 시 닫힘 구현 : `useRef` `current`를 사용해 구현
- [x] 리팩토링 : 날짜 선택을 하는 `setEventDate` 동작 `getConvertedPeriod`, `handleSetPeriod` 함수로 호출해서 중복을 제거했습니다.

### 기타
없음

close #42
