### PR TITLE
bug : detail page 축제 이미지 중복 제거 및 포스터 맨 앞으로 정렬

### DIFF
--- a/app/detail/[id]/components/DetailImageSwiper.tsx
+++ b/app/detail/[id]/components/DetailImageSwiper.tsx
@@ -15,10 +15,6 @@ import Image from "next/image";
 export default function DetailImageSwiper({ imageList }) {
     const [thumbsSwiper, setThumbsSwiper] = useState(null);
 
-    // const imageURLs = [
-    //     ...new Set([...imageList.map((festival) => festival.originimgurl)]),
-    // ];
-
     const imageURLs = [];
     const filteredImages = imageList.filter((festival) => {
         if (!imageURLs.includes(festival.originimgurl)) {


### PR DESCRIPTION
## detail page 축제 이미지 중복 제거 및 포스터 맨 앞으로 정렬

### ✅ 작업 내용

- [x] 축제 이미지 중복제거 : 이미지 URL을 비교해서 중복된 이미지를 필터링 했습니다.

|![2025-06-30 15 55 28](https://github.com/user-attachments/assets/14d07903-d4d9-46c3-8c69-391a7a54ff48)|![2025-06-30 15 55 59](https://github.com/user-attachments/assets/0f5258be-ead8-4f00-8108-0f6feba5c646)|
|--|--|

- [x] 포스터가 있으면 맨 앞으로 : 축제 이미지 중 포스터가 있다면 맨 앞으로 정렬했습니다.
`imgname` 이미지 이름에 포스터가 포함되면 맨 앞으로 정렬하는 작업을 수행했습니다. 

|![2025-06-30 15 54 00](https://github.com/user-attachments/assets/781f1614-ff83-41bc-8ef7-754faf63e723)|![2025-06-30 15 54 43](https://github.com/user-attachments/assets/0a91dbce-5933-4ce9-a743-9f91ca6ed471)|
|--|--|

### 기타
없음

close #54
