### PR TITLE
feature : 로그인 여부에 따라 헤더 변경 및 리다이렉션

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -9,10 +9,6 @@ import { getLastDayOfMonth, getToday } from "../../lib/utils";
 import { getFestivalList } from "../../lib/api/festival";
 import BackToTopButton from "../../components/BackToTopButton/BackToTopButton";
 
-import { createClient } from "../../lib/utils/server";
-import SignOutButton from "./components/authButton/SignOutButton";
-import DeleteAccountButton from "./components/authButton/DeleteAccountButton";
-
 export function generateMetadata() {
     return {
         title: "축제가자",
@@ -31,13 +27,6 @@ export default async function Page() {
         eventEndDate: lastDate,
         arrange: "Q",
     });
-
-    const supabase = createClient();
-    const {
-        data: { user },
-    } = await (await supabase).auth.getUser();
-
-    console.log(user);
 
     return (
         <>
@@ -61,13 +50,6 @@ export default async function Page() {
             </div>
 
             <BackToTopButton />
-
-            <div className=" absolute top-0 left-0">
-                <div>{user ? user.user_metadata.email : "not login"}</div>
-
-                {user ? <SignOutButton /> : null}
-                {user ? <DeleteAccountButton /> : null}
-            </div>
         </>
     );
 }

--- a/app/login/components/KakaoLoginButton.tsx
+++ b/app/login/components/KakaoLoginButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createClient } from "../../../lib/utils/client";
+
+export default async function KakaoLoginButton() {
+    const supabase = createClient();
+
+    // 카카오 로그인
+    async function signInWithKakao() {
+        await supabase.auth.signInWithOAuth({
+            provider: "kakao",
+            options: {
+                redirectTo: "http://localhost:3000/auth/callback",
+            },
+        });
+    }
+
+    return (
+        <button
+            onClick={() => signInWithKakao()}
+            className="row-center gap-[10px] bg-[#FEE500] py-[10px] px-[14px] mt-[20px] rounded-[8px] text-[#181602] font-semibold text-[14px]"
+        >
+            <img src="/assets/kakao.svg" alt="카카오 로그인" />
+            카카오로 시작하기
+        </button>
+    );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,41 +1,30 @@
-"use client";
-
 import Link from "next/link";
-import { createClient } from "../../lib/utils/client";
+import KakaoLoginButton from "./components/KakaoLoginButton";
+import { createClient } from "../../lib/utils/server";
+import { redirect } from "next/navigation";
 
-// export function generateMetadata() {
-//     return {
-//         title: "로그인 - 축제가자",
-//     };
-// }
+export function generateMetadata() {
+    return {
+        title: "로그인 - 축제가자",
+    };
+}
 
-export default function LoginPage() {
-    async function signInWithKakao() {
-        const supabase = await createClient();
-        // const { data, error } = await supabase.auth.signInWithOAuth({
-        //     provider: "kakao",
-        //     options: {
-        //         redirectTo: "http://localhost:3000/auth/callback",
-        //     },
-        // });
-        await supabase.auth.signInWithOAuth({
-            provider: "kakao",
-            options: {
-                redirectTo: "http://localhost:3000/auth/callback",
-            },
-        });
+export default async function LoginPage() {
+    const supabase = createClient();
+    const {
+        data: { user },
+    } = await (await supabase).auth.getUser();
+
+    // 로그인 O 라면 마이페이지로 리다이렉션
+    if (user) {
+        redirect("/mypage");
     }
 
     return (
         <div className="min-max-padding min-h-[400px] md:min-h-[600px] col-center justify-center gap-[10px]">
-            <button
-                onClick={() => signInWithKakao()}
-                className="row-center gap-[10px] bg-[#FEE500] py-[10px] px-[14px] mt-[20px] rounded-[8px] text-[#181602] font-semibold text-[14px]"
-            >
-                <img src="/assets/kakao.svg" alt="카카오 로그인" />
-                카카오로 시작하기
-            </button>
-
+            {/* 카카오 로그인 버튼 */}
+            <KakaoLoginButton />
+            {/* 홈으로 이동 버튼 */}
             <Link href="/" className="mt-[20px]">
                 <button className="row-center gap-[10px] font-semibold text-[14px]">
                     <img

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,8 +1,22 @@
+import { redirect } from "next/navigation";
 import { createClient } from "../../lib/utils/server";
 
-export default async function Mypage() {
-    const supabase = await createClient();
-    const { data: instruments } = await supabase.from("instruments").select();
+export function generateMetadata() {
+    return {
+        title: "마이페이지 - 축제가자",
+    };
+}
 
-    return <pre>{JSON.stringify(instruments, null, 2)}</pre>;
+export default async function Mypage() {
+    const supabase = createClient();
+    const {
+        data: { user },
+    } = await (await supabase).auth.getUser();
+
+    // 로그인 X 라면 로그인 페이지로 리다이렉션
+    if (!user) {
+        redirect("/login");
+    }
+
+    return <div>마이페이지</div>;
 }

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,8 +1,18 @@
 import Link from "next/link";
 import Button from "../Button/Button";
 import Navigation from "./Navigation";
+import { createClient } from "../../lib/utils/server";
 
-export default function Header({ mockPathname }: { mockPathname?: string }) {
+export default async function Header({
+    mockPathname,
+}: {
+    mockPathname?: string;
+}) {
+    const supabase = createClient();
+    const {
+        data: { user },
+    } = await (await supabase).auth.getUser();
+
     return (
         <header className="min-max-padding">
             <div className="md:h-[76px] h-[56px] flex justify-between items-center">
@@ -14,18 +24,15 @@ export default function Header({ mockPathname }: { mockPathname?: string }) {
                     />
                 </Link>
 
-                {/* web */}
-                <Link href={`/login`} className="hidden md:block">
-                    <Button title="로그인/회원가입" />
-                </Link>
-                {/* mobile */}
-                <Link href={`/login`} className="h-[30px] block md:hidden">
-                    <img
-                        src="/assets/profile.svg"
-                        alt="profile"
-                        className="h-full"
-                    />
-                </Link>
+                {user ? (
+                    <Link href={`/mypage`} className="row-center gap-[7px]">
+                        <Button title="마이페이지" />
+                    </Link>
+                ) : (
+                    <Link href={`/login`}>
+                        <Button title="로그인/회원가입" />
+                    </Link>
+                )}
             </div>
 
             <Navigation mockPathname={mockPathname} />


### PR DESCRIPTION
## (이슈 제목)
로그인 여부에 따라 헤더 변경 및 리다이렉션

### ✅ 작업 내용
- [x] 로그인 여부에 따라 헤더 변경
- [x] 마이페이지 경로 생성
- [x] 로그인 여부에 따라 `/mypage`, `/login` 서로 리다이렉션

### 기타
없음

close #90 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 OAuth 로그인을 위한 카카오 로그인 버튼이 추가되었습니다.
  * 로그인 및 마이페이지에서 페이지 제목이 표시됩니다.

* **버그 수정**
  * 로그인 페이지와 마이페이지에서 로그인 상태를 서버에서 확인하고, 미로그인 시 자동으로 리다이렉트됩니다.

* **기능 개선**
  * 헤더에서 로그인 상태에 따라 "마이페이지" 또는 "로그인/회원가입" 버튼이 조건부로 표시됩니다.
  * 마이페이지에서 악기 목록 대신 간단한 "마이페이지" 텍스트만 표시됩니다.
  * 홈 화면에서 사용자 인증 관련 UI가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->