### PR TITLE
bug :  mypage 모든 후기 삭제 에러 처리 수정 및 구분선 이동

### DIFF
--- a/app/detail/[id]/components/DetailRatingSection.tsx
+++ b/app/detail/[id]/components/DetailRatingSection.tsx
@@ -8,7 +8,6 @@ import { useWriteReviewModalStore } from "../../../../stores/useWriteReviewModal
 import { useAlertStore } from "../../../../stores/useAlertStore";
 import { createClient } from "../../../../lib/utils/client";
 import { useRouter } from "next/navigation";
-import { error } from "console";
 
 export default function DetailRatingSection({
     contentId,

--- a/app/mypage/components/UserDeleteAccountSection.tsx
+++ b/app/mypage/components/UserDeleteAccountSection.tsx
@@ -6,14 +6,11 @@ import { createClient } from "../../../lib/utils/client";
 import { useAlertStore } from "../../../stores/useAlertStore";
 import { useModalStore } from "../../../stores/useModalStore";
 import DeleteAccountButton from "./DeleteAccountButton/DeleteAccountButton";
-import { useState } from "react";
 
 export default function UserDeleteAccountSection({ userId }) {
     const router = useRouter();
     const { open: modalOpen, close: modalClose } = useModalStore();
     const { open: alertOpen, close: alertClose } = useAlertStore();
-
-    const [deleteError, setDeleteError] = useState(null);
 
     const deleteAllReviews = async () => {
         const supabase = createClient();
@@ -22,9 +19,7 @@ export default function UserDeleteAccountSection({ userId }) {
             .delete()
             .eq("user_id", userId);
 
-        if (error) {
-            setDeleteError(error);
-        }
+        return error;
     };
 
     const handleDeleteAllRating = () => {
@@ -36,7 +31,7 @@ export default function UserDeleteAccountSection({ userId }) {
             "삭제할게요",
             async () => {
                 // 모든 축제 삭제
-                await deleteAllReviews();
+                const error = await deleteAllReviews();
 
                 // 모달창 닫기
                 modalClose();
@@ -44,7 +39,7 @@ export default function UserDeleteAccountSection({ userId }) {
                 // 리프레시
                 router.refresh();
 
-                if (deleteError !== null) {
+                if (!error) {
                     // 성공알람
                     alertOpen("작성하신 모든 후기를 삭제했습니다.");
                 } else {

--- a/app/mypage/components/UserReview/UserReview.tsx
+++ b/app/mypage/components/UserReview/UserReview.tsx
@@ -33,6 +33,7 @@ export default function UserReview({ review }) {
 
     return (
         <>
+            <span className="w-full bg-border-base h-[1px]" />
             <Link
                 href={`/detail/${review.contentId}`}
                 target="_blank"
@@ -58,8 +59,6 @@ export default function UserReview({ review }) {
                     {review.content}
                 </p>
             </Link>
-
-            <span className="w-full bg-border-base h-[1px]" />
         </>
     );
 }


### PR DESCRIPTION
## mypage 모든 후기 삭제 에러 처리 수정 및 구분선 이동

### ✅ 작업 내용
- [x] 모든 후기 삭제 에러 처리 방식 변경 : 이제 정상적으로 모든 후기 삭제 시 완료 알람이 뜹니다.

- [x] 마이페이지 내 후기 구분선 하단에서 상단으로 이동

### 기타
후기가 없을 때 모든 후기 삭제 이벤트를 하지 않고 "작성한 후기가 없습니다." 알람을 띄우도록 개발

close #108 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음
- 버그 수정
  - 계정 삭제 진행 후 성공/실패 알림이 간헐적으로 반대로 표시되던 문제를 수정하여 알림이 정확히 표시됩니다.
- 스타일
  - 마이페이지 리뷰 목록의 구분선 위치를 조정하여 각 항목 상단에만 구분선이 표시되도록 개선했습니다.
- 리팩터링/잡무
  - 불필요한 코드와 미사용 의존성을 정리하여 코드 가독성과 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->