### PR TITLE
feature : 로그인 여부에 따른 후기 작성 버튼 분기 처리

### DIFF
--- a/app/detail/[id]/components/DetailRatingSection.tsx
+++ b/app/detail/[id]/components/DetailRatingSection.tsx
@@ -8,6 +8,7 @@ import { useWriteReviewModalStore } from "../../../../stores/useWriteReviewModal
 import { useAlertStore } from "../../../../stores/useAlertStore";
 import { createClient } from "../../../../lib/utils/client";
 import { useRouter } from "next/navigation";
+import { useModalStore } from "../../../../stores/useModalStore";
 
 export default function DetailRatingSection({
     contentId,
@@ -26,6 +27,7 @@ export default function DetailRatingSection({
     const { open: writeModalOpen, close: writeModalClose } =
         useWriteReviewModalStore();
     const { open: alertOpen, close: alertClose } = useAlertStore();
+    const { open: modalOpen, close: modalClose } = useModalStore();
 
     // 보여줄 리뷰 수
     const [page, setPage] = useState(3);
@@ -75,7 +77,6 @@ export default function DetailRatingSection({
 
         if (user) {
             // 로그인 한 경우
-            console.log("로그인 한 경우");
             writeModalOpen(title, contentId, async (rating, content) => {
                 // 축제 후기 작성
                 const error = await writeReview(rating, content);
@@ -94,8 +95,15 @@ export default function DetailRatingSection({
             });
         } else {
             // 로그인 하지 않은 경우
-            console.log("로그인 하지 않은 경우");
-            alertOpen("로그인이 필요한 서비스입니다.");
+            modalOpen(
+                "후기 작성",
+                "후기 작성은 로그인이 필요한 서비스입니다.",
+                "로그인 하기",
+                () => {
+                    modalClose();
+                    router.push("/login"); // 로그인 페이지로 이동
+                }
+            );
         }
     };
 


### PR DESCRIPTION
## 로그인 여부에 따른 후기 작성 버튼 분기 처리

<img width="1896" height="894" alt="2025-08-16 15 40 08" src="https://github.com/user-attachments/assets/a527a4be-7680-4089-b1f6-8bdff29b5238" />

### ✅ 작업 내용
- [x] 후기 작성 버튼에 로그인 여부 확인 및 모달창

### 기타
없음

close #117 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비로그인 사용자가 후기 작성 시 경고창 대신 로그인 안내 모달을 표시합니다(제목: “후기 작성”, 로그인 필요 안내).
  * 모달에서 “로그인 하기”를 선택하면 모달이 닫히고 로그인 페이지(/login)로 이동합니다.
  * 로그인 사용자의 후기 작성 흐름은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->