### PR TITLE
feature : mypage, detailpage loading 스켈레톤 로딩

### DIFF
--- a/app/detail/[id]/loading.tsx
+++ b/app/detail/[id]/loading.tsx
@@ -1,5 +1,4 @@
 import Button from "../../../components/Button/Button";
-import FavoriteButton from "../../../components/FavoriteButton/FavoriteButton";
 import DetailHeader from "./components/DetailHeader";
 
 export default function Loading() {
@@ -30,6 +29,25 @@ export default function Loading() {
                 <div className="md:h-[27px] h-[23px] w-[20%] bg-background-hover rounded" />
                 <div className="md:h-[27px] h-[23px] w-[20%] bg-background-hover rounded" />
                 <div className="md:h-[120px] h-[60px] w-full bg-background-hover rounded" />
+            </div>
+
+            {/* 축제 후기 */}
+            <div className="flex flex-col md:gap-[25px] gap-[20px] border border-border-base rounded-[8px] py-[16px] px-[14px] md:py-[36px] md:px-[30px] mb-[40px] mt-[20px]">
+                <div className="row-center justify-between">
+                    <h2 className="md:text-[24px] text-[16px] font-semibold">
+                        축제 후기
+                    </h2>
+                    <Button title="후기 작성" icon="/assets/open_in_new.svg" />
+                </div>
+                <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
+                <span className="w-full bg-border-base h-[1px]" />
+                <div className="row-center justify-between">
+                    <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
+                    <div className="h-[21px] md:h-[24px] w-[24px] rounded bg-background-hover" />
+                </div>
+
+                <div className="h-[21px] md:h-[24px] w-[70%] rounded bg-background-hover" />
+                <div className="h-[21px] md:h-[24px] w-[100%] rounded bg-background-hover" />
             </div>
 
             {/* 축제 상세 정보 */}

--- a/app/detail/[id]/loading.tsx
+++ b/app/detail/[id]/loading.tsx
@@ -40,14 +40,15 @@ export default function Loading() {
                     <Button title="후기 작성" icon="/assets/open_in_new.svg" />
                 </div>
                 <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
-                <span className="w-full bg-border-base h-[1px]" />
                 <div className="row-center justify-between">
-                    <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
-                    <div className="h-[21px] md:h-[24px] w-[24px] rounded bg-background-hover" />
+                    <div className="h-[21px] md:h-[24px] w-[10%] rounded bg-background-hover" />
+                    <div className="h-[18px] md:h-[20px] md:w-[36px] w-[30px] rounded bg-background-hover" />
                 </div>
 
-                <div className="h-[21px] md:h-[24px] w-[70%] rounded bg-background-hover" />
-                <div className="h-[21px] md:h-[24px] w-[100%] rounded bg-background-hover" />
+                <div className="flex flex-col gap-[5px]">
+                    <div className="h-[21px] md:h-[24px] w-[100%] rounded bg-background-hover" />
+                    <div className="h-[21px] md:h-[24px] w-[70%] rounded bg-background-hover" />
+                </div>
             </div>
 
             {/* 축제 상세 정보 */}

--- a/app/detail/[id]/page.tsx
+++ b/app/detail/[id]/page.tsx
@@ -34,6 +34,9 @@ export default async function DetailPage({
 }: {
     params: Promise<{ id: string }>;
 }) {
+    // 로딩 페이지 개발을 위해 무한 대기
+    // await new Promise(() => {});
+
     const { id: contentId } = await params;
     const supabase = createClient();
 

--- a/app/mypage/loading.tsx
+++ b/app/mypage/loading.tsx
@@ -1,0 +1,47 @@
+export default function Loading() {
+    return (
+        <div className="min-max-padding bg-background-base animate-pulse">
+            {/* 내 정보 */}
+            <div className="flex flex-col md:gap-[25px] gap-[20px] border border-border-base rounded-[8px] py-[16px] px-[14px] my-[41px] md:py-[36px] md:px-[30px] mb-[40px]">
+                <h2 className="md:text-[24px] text-[16px] font-semibold">
+                    내 정보
+                </h2>
+
+                <div className="row-center gap-[15px]">
+                    <div className="md:h-[54px] h-[44px] md:w-[54px] w-[44px] rounded-full bg-background-hover shrink-0" />
+
+                    <div className="flex flex-col md:h-[54px] h-[44px] w-full justify-between">
+                        <div className="md:h-[25px] h-[20px] md:w-[10%] w-[30%] bg-background-hover rounded" />
+                        <div className="md:h-[20px] h-[17px] md:w-[20%] w-[60%] bg-background-hover rounded" />
+                    </div>
+                </div>
+            </div>
+
+            {/* 내 정보 */}
+            <div className="flex flex-col md:gap-[25px] gap-[20px] border border-border-base rounded-[8px] py-[16px] px-[14px] my-[41px] md:py-[36px] md:px-[30px] mb-[40px]">
+                <h2 className="md:text-[24px] text-[16px] font-semibold">
+                    내 후기 관리
+                </h2>
+
+                <span className="w-full bg-border-base h-[1px]" />
+
+                <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
+                <div className="row-center justify-between">
+                    <div className="h-[21px] md:h-[24px] w-[10%] rounded bg-background-hover" />
+                    <div className="h-[18px] md:h-[20px] md:w-[36px] w-[30px] rounded bg-background-hover" />
+                </div>
+
+                <div className="flex flex-col gap-[5px]">
+                    <div className="h-[21px] md:h-[24px] w-[100%] rounded bg-background-hover" />
+                    <div className="h-[21px] md:h-[24px] w-[70%] rounded bg-background-hover" />
+                </div>
+            </div>
+
+            {/* 후기 삭제, 탈퇴 */}
+            <div className="flex flex-col md:gap-[25px] gap-[20px] border border-border-base rounded-[8px] py-[16px] px-[14px] my-[41px] md:py-[36px] md:px-[30px] mb-[40px]">
+                <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
+                <div className="h-[21px] md:h-[24px] w-[20%] rounded bg-background-hover" />
+            </div>
+        </div>
+    );
+}

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -11,6 +11,9 @@ export function generateMetadata() {
 }
 
 export default async function Mypage() {
+    // 로딩 페이지 개발을 위해 무한 대기
+    // await new Promise(() => {});
+
     const supabase = createClient();
 
     const {


### PR DESCRIPTION
## mypage, detailpage loading 스켈레톤 로딩

상세페이지의 후기 섹션과 마이페이지 loading 스켈레톤 로딩 작업을 수행하였습니다.

|<img width="803" height="1378" alt="2025-08-18 17 46 57" src="https://github.com/user-attachments/assets/6a43c468-a02c-4fed-a78f-d40e351251ca" />|<img width="1294" height="1378" alt="2025-08-18 17 47 22" src="https://github.com/user-attachments/assets/019260c1-d237-40ee-b238-5f5082a998c3" />|
|--|--|

### ✅ 작업 내용
- [x] 상세페이지 : 후기 섹션 스켈레톤 로딩
- [x] 마이페이지 : loading 스켈레톤 로딩 

### 기타
없음

close #99 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 상세 페이지 로딩 화면 개선: ‘축제 후기’ 섹션과 ‘후기 작성’ 버튼을 포함한 스켈레톤 UI 추가로 로딩 중 레이아웃 확인 가능.
  - 마이페이지 로딩 화면 추가: ‘내 정보’, ‘내 후기 관리’, ‘후기 삭제·탈퇴’ 카드형 스켈레톤 제공으로 일관된 로딩 경험 제공.

- Chores
  - 동작에 영향 없는 주석 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->