### PR TITLE
feature : 카카오 세션 끊기 및 리다이렉트 주소 등록

### DIFF
--- a/app/mypage/components/SignOutButton/SignOutButton.tsx
+++ b/app/mypage/components/SignOutButton/SignOutButton.tsx
@@ -1,17 +1,19 @@
 "use client";
-import { redirect, useRouter } from "next/navigation";
 import Button from "../../../../components/Button/Button";
 import { createClient } from "../../../../lib/utils/client";
 
 export default function SignOutButton() {
     const supabase = createClient();
-    const router = useRouter();
 
     async function handleLogout() {
+        // supabse 세션 종료
         await supabase.auth.signOut();
 
-        // 새로고침하면서 홈으로 이동을 위해
-        window.location.href = "/";
+        const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_KAKAO_MAP_KEY;
+        const LOGOUT_REDIRECT_URI = process.env.NEXT_PUBLIC_BASE_URL; // 리다이렉트 주소 : 홈으로 이동
+
+        // 카카오에서 리다이렉트 주소 등록
+        window.location.href = `https://kauth.kakao.com/oauth/logout?client_id=${KAKAO_REST_API_KEY}&logout_redirect_uri=${LOGOUT_REDIRECT_URI}`;
     }
 
     return <Button title="로그아웃" onClick={handleLogout} />;


### PR DESCRIPTION
## 카카오 세션 끊기 및 리다이렉트 주소 등록

<img width="1920" height="1104" alt="2025-08-19 10 22 25" src="https://github.com/user-attachments/assets/9ac109d6-2bfe-4102-8655-9dbf0a8acdf5" />

### ✅ 작업 내용
- [x] 카카오 개발자 콘솔 > 카카오 로그인 > 고급에서 로그아웃 리다이렉트 URL 등록을 했습니다.
- [x] 로그아웃 버튼 클릭 > supabase 세션 로그아웃 및 카카오 로그아웃 주소 연결
  - 축제가자 사이트만 로그아웃할지 완전히 로그아웃할지 선택 가능
  - 완전히 로그아웃 시 다음 로그인 할 때 이전 로그인 했던 계정으로 자동 로그인 되는 것을 막았습니다.

### 기타
없음

close #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 로그아웃 후 카카오 OAuth 로그아웃 페이지로 이동하여 연동 계정까지 완전 로그아웃됩니다.
  * 브라우저 전체 페이지 리다이렉트를 사용해 세션 정리를 보장합니다.
  * 기존의 홈("/") 이동 대신 더 일관된 종료 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->